### PR TITLE
set appendonly no and save "" for redis cluster deploys. 

### DIFF
--- a/src/templates/redis.conf.tmpl
+++ b/src/templates/redis.conf.tmpl
@@ -1,5 +1,6 @@
 {%- if cluster_conf is defined %}
-appendonly yes
+save ""
+appendonly no
 cluster-enabled yes
 cluster-config-file {{cluster_conf}}
 cluster-node-timeout 5000


### PR DESCRIPTION
redis cluster should generally avoid application-level persistence to support high capacity reads and writes. potentially these should later be made configurable in the context of the charm