### PR TITLE
Only the leader should call leader_set.

### DIFF
--- a/src/reactive/redis.py
+++ b/src/reactive/redis.py
@@ -183,7 +183,8 @@ def set_redis_version():
         return
 
 
-@when('redis.cluster.enabled')
+@when('redis.cluster.enabled',
+      'leadership.is_leader')
 @when_not('leadership.set.init_masters')
 @when_any('endpoint.cluster.peer.joined',
           'endpoint.cluster.peer.changed')


### PR DESCRIPTION
Negate spurious traceback by ensuring only the leader runs
leader_set().